### PR TITLE
updated nokogiri to 1.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,19 +74,21 @@ GEM
     method_source (0.9.2)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.1)
     minitest-around (0.4.1)
       minitest (~> 5.0)
     nio4r (2.5.2)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.0.7)
       rack
@@ -169,4 +171,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
nokogiri needs an update because they report a security vulnerability: https://github.com/advisories/GHSA-vr8q-g5c7-m54m